### PR TITLE
Select lexer for all fenced code blocks

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -3,7 +3,7 @@
 Create the stack using the existing stack's management network and security
 group:
 
-```
+```bash
 openstack stack create \
     --template heat-templates/hot/edx-analytics-server.yaml \
     --parameter name=<server_name> \
@@ -19,7 +19,7 @@ openstack stack create \
 The analytics server's default internal IP is `192.168.122.120`.  Deploy the
 stack's SSH key pair to it from the deploy node:
 
-```
+```bash
 ip=192.168.122.120
 ssh-keyscan $ip >> ~/.ssh/known_hosts
 ssh-copy-id -i ~/.ssh/id_rsa $ip
@@ -30,9 +30,10 @@ You'll create a static inventory file, `analytics.ini`, containing the
 existing `backend_servers`, and only the analytics server under
 `analytics_servers`:
 
-```
+```bash
 vim /var/tmp/edx-configuration-secrets/analytics.ini
-...
+
+```ini
 [analytics_servers]
 192.168.122.120
 
@@ -44,14 +45,14 @@ vim /var/tmp/edx-configuration-secrets/analytics.ini
 
 You can find out what are the existing backend servers by running:
 
-```
+```bash
 /var/tmp/edx-configuration-secrets/openstack.py --list
 ```
 
 Now, run the `openstack-analytics.yaml` playbook using this inventory file on
 the `analytics_servers` group.
 
-```
+```bash
 cd /var/tmp/edx-configuration/playbooks
 ansible-playbook \
     -i ../../edx-configuration-secrets/analytics.ini \
@@ -61,13 +62,13 @@ ansible-playbook \
 
 SSH into the the analytics node for the following:
 
-```
+```bash
 ssh 192.168.122.120
 ```
 
 Set up the pipeline in a new virtual env:
 
-```
+```bash
 # Create a new virtualenv for the pipeline, and activate it
 virtualenv pipeline
 . pipeline/bin/activate
@@ -80,9 +81,12 @@ make bootstrap
 
 Copy the sample `devstack.cfg` configuration file and change it as follows:
 
-```
+```bash
 sudo cp ~/edx-analytics-pipeline/config/devstack.cfg /edx/etc/edx-analytics-pipeline/override.cfg
 sudo vim /edx/etc/edx-analytics-pipeline/override.cfg
+```
+
+```ini
 ...
 [elasticsearch]
 host = http://192.168.122.111:9201/
@@ -92,7 +96,7 @@ Test it with a simple task that counts daily events.  This will run through the
 installation procedure and may take a while.  On subsequent invocations,
 however, it will be possible to skip it.
 
-```
+```bash
 remote-task \
     --host localhost \
     --repo https://github.com/edx/edx-analytics-pipeline \
@@ -107,7 +111,7 @@ remote-task \
 
 Now import enrollments, skipping the installation:
 
-```
+```bash
 remote-task \
     --host localhost \
     --user ubuntu \

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -14,7 +14,9 @@ maintained in rotation for each instance and database.
 
 It is recommended that this playbook be run with:
 
-    --limit <secondary_backend_node>
+```bash
+--limit <secondary_backend_node>
+```
 
 With the sample multi-node Heat template, it would either be `--limit
 192.168.122.112` or `--limit 192.168.122.113`.  It should not be targetted on
@@ -35,7 +37,7 @@ To run the backup playbook on a schedule, create a cron file such as
 `/etc/cron.d/backup`.  If you wish to run the backup daily at 01:05 AM, for
 example, copy the following lines into the file:
 
-```
+```cron
 # /etc/cron.d/backup: cron entry for backups
 
 SHELL=/bin/sh
@@ -54,7 +56,7 @@ that Ansible can connect to the backend node without human intervention.  (You
 can skip this step if you've already done it as part of initial stack
 deployment.)
 
-```sh
+```bash
 # Create a new key pair
 export KEYFILE=~/.ssh/id_rsa
 ssh-keygen -t rsa -N "" -f $KEYFILE

--- a/docs/deployment/multiple-ansible.md
+++ b/docs/deployment/multiple-ansible.md
@@ -13,7 +13,7 @@ parameters when invoking Heat:
 
 In addition, you must set the name of the stack.
 
-```
+```bash
 stack=<stack_name>
 openstack stack create \
     --template heat-templates/hot/edx-multi-node.yaml \
@@ -25,7 +25,7 @@ openstack stack create \
 
 To verify that the stack has reached the `CREATE_COMPLETE` state, run:
 
-```
+```bash
 openstack stack show $stack
 ```
 
@@ -33,7 +33,7 @@ Once stack creation is complete, you can use `openstack stack output show` to
 retrieve the IP address of your deployment host, and then to connect to it,
 making sure to forward your SSH authentication agent:
 
-```
+```bash
 openstack stack output show $stack deploy_ip
 ssh ubuntu@<deploy_ip> -A
 ```
@@ -44,7 +44,7 @@ variables, which will configure this deployment of Open edX.  Due to how
 Ansible variable precedence works, it is recommended that you copy the sample
 ones to a separate directory:
 
-```
+```bash
 git clone https://github.com/hastexo/edx-configuration.git -b hastexo/integration/base
 cp -a edx-configuration/playbooks/openstack edx-configuration-secrets
 cd edx-configuration-secrets/group_vars
@@ -59,7 +59,7 @@ work correctly in an OpenStack cluster.  To do so, edit
 `edx-configuration-secrets/group_vars/all`, and replace the repository
 variables with the following:
 
-```
+```yaml
 # Repos
 edx_platform_repo: "https://{{ COMMON_GIT_MIRROR }}/hastexo/edx-platform.git"
 edx_platform_version: "hastexo/integration/hastexo"
@@ -85,7 +85,7 @@ connections originating from the site itself:
     `edx-configuration-secrets/group_vars/all` and replacing `EDXAPP_SITE_NAME`
     with the desired domain.
 
-```
+```bash
 site=lms.example.com
 openstack container create $site
 openstack container set --property "read_acl=.r:$site" $site
@@ -106,7 +106,7 @@ add the nodes to the host list so one doesn't have to manually confirm them
 later.  Note that this will only work if authentication forwarding is properly
 configured, and if you're logged in as the default user, "ubuntu".
 
-```sh
+```bash
 # Create a new key pair
 export KEYFILE=~/.ssh/id_rsa
 ssh-keygen -t rsa -N "" -f $KEYFILE
@@ -127,7 +127,7 @@ forwarding, as the latter can interfere with the Ansible deployment.  Ideally,
 start a screen session as well, so a disconnection will not stop the Ansible
 run:
 
-```
+```bash
 exit
 ssh ubuntu@<deploy_ip>
 screen
@@ -138,7 +138,7 @@ the static `intentory.ini`, meant for single node deployments.  Also, set
 `migrate_db=yes` on this first run, to ensure that the databases and tables are
 properly created.
 
-```
+```bash
 cd ~/edx-configuration/playbooks
 ansible-playbook -i ../../edx-configuration-secrets/inventory.py openstack-multi-node.yml -e migrate_db=yes
 ```
@@ -148,7 +148,7 @@ deploy node and edit your local /etc/hosts.  If you didn't change any of the
 example variables, enter the following, substituting `app_ip` for the IP
 address of the app server pool you can obtain with the following command:
 
-```
+```bash
 openstack stack output show $stack app_ip
 vim /etc/hosts
 ---
@@ -165,7 +165,7 @@ To deploy additional application servers within a previously deployed
 stack, use the `openstack stack update` command to increase the `app_count`
 stack parameter:
 
-```
+```bash
 openstack stack update --existing --parameter app_count=<new_num> $stack
 ```
 
@@ -175,7 +175,7 @@ If you added app servers, however, log back into the deploy node, and run the
 multi-node playbook again, limiting the run to the app servers and avoiding
 database migrations:
 
-```
+```bash
 cd /var/tmp/edx-configuration/playbooks
 ansible-playbook -i ../../edx-configuration-secrets/inventory.py openstack-multi-node.yml --limit app_servers
 ```
@@ -190,7 +190,7 @@ node cluster, go back to your deploy node and:
   created above) and change them as described.  Set the `os_*`
   variables to the OpenStack cloud of your choice.
 
-```
+```yaml
 EDXAPP_EXTRA_REQUIREMENTS:
   - name: "git+https://github.com/hastexo/hastexo-xblock.git@master#egg=hastexo-xblock"
 EDXAPP_ADDL_INSTALLED_APPS:
@@ -216,7 +216,7 @@ EDXAPP_XBLOCK_SETTINGS:
 - Add the `gateone` role to `openstack-multi-node.yml` under the
   `app_servers` section (the last one).
 
-```
+```bash
 $ cd ~/edx-configuration/playbooks
 $ vim openstack-multi-node.yaml
 ...
@@ -227,6 +227,6 @@ $ vim openstack-multi-node.yaml
 
 - Run that playbook, limitting the run to the `app_servers`:
 
-```
+```bash
 $ ansible-playbook -i ../../edx-configuration-secrets/inventory.py openstack-multi-node.yml --limit app_servers
 ```

--- a/docs/deployment/multiple-master.md
+++ b/docs/deployment/multiple-master.md
@@ -14,7 +14,7 @@ request it to be created by the the existing stack, or you you can use the
 
 To request the existing stack to create a new app master server, invoke:
 
-```
+```bash
 stack=<existing_stack_name>
 master_base_image=<master_base_image>
 openstack stack update \
@@ -27,7 +27,7 @@ openstack stack update \
 Now, run the `openstack-multi-node.yaml` playbook on the app master from the
 deploy node.  You may also want to run database migrations at this point:
 
-```
+```bash
 cd ~/edx-configuration/playbooks
 ansible-playbook \
     -i ../../edx-configuration-secrets/inventory.py \
@@ -38,7 +38,7 @@ ansible-playbook \
 After the run finishes, go back to your local terminal to stop the server, and
 create an image from it:
 
-```
+```bash
 stack=<your_stack_name>
 image=<your_image_name>
 eval $(openstack stack output show $stack app_master_id --format shell)
@@ -48,14 +48,14 @@ openstack server image create --name $image ${output_value}
 
 Run the following to keep tabs on the image creation.
 
-```
+```bash
 openstack image show $image
 ```
 
 Once it's active, you're free to disable the app master server and
 simultaneously configure the app servers to use the new image:
 
-```
+```bash
 openstack stack update \
     --existing \
     --parameter enable_app_master=0
@@ -78,7 +78,7 @@ mandatory parameters when invoking Heat:
 
 You can find out the management network ID and security group ID by issuing:
 
-```
+```bash
 openstack stack resource show <existing_stack_name> management_net | grep physical_resource_id
 openstack stack resource show <existing_stack_name> server_security_group | grep physical_resource_id
 ```
@@ -88,7 +88,7 @@ stack.
 
 Finally, this is how you would create the auxiliary stack:
 
-```
+```bash
 openstack stack create \
     --template heat-templates/hot/edx-app-master.yaml \
     --parameter name=<server_name> \
@@ -102,14 +102,14 @@ openstack stack create \
 
 To verify that the stack has reached the `CREATE_COMPLETE` state, run:
 
-```
+```bash
 openstack stack show <stack_name>
 ```
 
 Once stack creation is complete, you can use `openstack stack output show` to
 retrieve the internal IP address of the app master server:
 
-```
+```bash
 openstack stack output show <stack_name> server_ip
 ...
 "192.168.122.206"
@@ -117,7 +117,7 @@ openstack stack output show <stack_name> server_ip
 
 Now, SSH into the existing stack's deploy node:
 
-```
+```bash
 openstack stack output show <existing_stack_name> deploy_ip
 ssh ubuntu@<deploy_ip>
 ```
@@ -125,9 +125,11 @@ ssh ubuntu@<deploy_ip>
 You'll create a static inventory file, `app_master.ini`, containing the
 existing `backend_servers`, and only the app master under `app_master`:
 
-```
+```bash
 vim /var/tmp/edx-configuration-secrets/app_master.ini
-...
+```
+
+```ini
 [app_master]
 192.168.122.206
 
@@ -139,7 +141,7 @@ vim /var/tmp/edx-configuration-secrets/app_master.ini
 
 You can find out what are the existing backend servers by running:
 
-```
+```bash
 /var/tmp/edx-configuration-secrets/openstack.py --list
 ```
 
@@ -147,7 +149,7 @@ Now, run the `openstack-multi-node.yaml` playbook using this inventory file on
 the `app_master` group.  You may also want to run database migrations at this
 point:
 
-```
+```bash
 cd /var/tmp/edx-configuration/playbooks
 ansible-playbook \
     -i ../../edx-configuration-secrets/app_master.ini \
@@ -158,26 +160,26 @@ ansible-playbook \
 After the run finishes, go back to your local terminal stop the server, and
 create an image from it:
 
-```
+```bash
 openstack server stop <server_name>
 openstack server image create --name <image_name> <server_name>
 ```
 
 Run the following to keep tabs on the image creation.
 
-```
+```bash
 openstack image show <image_name>
 ```
 
 Once it's active, you're free to delete the app master stack:
 
-```
+```bash
 openstack stack delete <stack_name>
 ```
 
 And finally, you can use the image to update your existing stack.  For example:
 
-```
+```bash
 openstack stack update \
     --existing \
     --parameter app_image=<image_name> \

--- a/docs/deployment/single-ansible.md
+++ b/docs/deployment/single-ansible.md
@@ -9,7 +9,7 @@ set two mandatory parameters when invoking Heat:
 - `key_name`, which is the name of the Nova keypair that you'll be
   using to log in once the machines have spun up.
 
-```
+```bash
 openstack stack create \
     --template heat-templates/hot/edx-single-node.yaml \
     --parameter public_net_id=<uuid> \
@@ -19,14 +19,14 @@ openstack stack create \
 
 To verify that the stack has reached the `CREATE_COMPLETE` state, run:
 
-```
+```bash
 openstack stack show <stack_name>
 ```
 
 Once stack creation is complete, you can use `heat output-show` to
 retrieve the IP address of your Open edX host:
 
-```
+```bash
 openstack stack output show <stack_name> public_ip
 ssh ubuntu@<public_ip>
 ```
@@ -42,7 +42,7 @@ which will configure this deployment of Open edX.  Due to how Ansible variable
 precedence works, it is recommended that you copy the sample ones to a separate
 directory:
 
-```
+```bash
 cp /var/tmp/edx-configuration/playbooks/openstack /var/tmp/edx-configuration-secrets
 cd /var/tmp/edx-configuration-secrets/host_vars
 cp localhost.example localhost
@@ -75,7 +75,7 @@ node, go back to your installed node and:
   created above) and change them as described.  Set the `os_*`
   variables to the OpenStack cloud of your choice.
 
-```
+```yaml
 EDXAPP_EXTRA_REQUIREMENTS:
   - name: "git+https://github.com/hastexo/hastexo-xblock.git@master#egg=hastexo-xblock"
 EDXAPP_ADDL_INSTALLED_APPS:
@@ -101,7 +101,7 @@ EDXAPP_XBLOCK_SETTINGS:
 - Check out the `hastexo/integration/base` branch of
   edx-configuration, which contains the `gateone` role:
 
-```
+```bash
 $ cd /var/tmp/edx-configuration
 $ git checkout -b hastexo/integration/base origin/hastexo/integration/base
 ```
@@ -109,7 +109,7 @@ $ git checkout -b hastexo/integration/base origin/hastexo/integration/base
 - Add the `gateone` role to `openstack-single-node.yml` and rerun that
   playbook:
 
-```
+```bash
 $ cd /var/tmp/edx-configuration/playbooks
 $ vim openstack-single-node.yaml
  ...


### PR DESCRIPTION
Though MkDocs by itself is fine with auto-detecting a fenced code block's syntax and selecting the appropriate lexer, the Read The Docs MkDocs builder is not. Explicitly declare code block syntax to be safe.